### PR TITLE
Improve support for environment types and fix description of plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,7 @@
 
 ## Overview
 
-This plugin will prevent indexing of a site when `DISALLOW_INDEXING` is set to `true`
-and display a notice in the WordPress dashboard with a reference to the value of
-[`WP_ENV`](https://docs.roots.io/bedrock/master/environment-variables/#wp-env) or
-[`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/).
+This plugin will prevent indexing of a site when `DISALLOW_INDEXING` is set to `true` and display a notice in the WordPress dashboard with a reference to the value of [`WP_ENV`](https://roots.io/bedrock/docs/environment-variables/#wp-env) or [`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/).
 
 ## Support us
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@
 
 ## Overview
 
-This plugin will prevent indexing of a site when [`WP_ENV`](https://docs.roots.io/bedrock/master/environment-variables/#wp-env) or [`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/) is not set to `production`.
+This plugin will prevent indexing of a site when `DISALLOW_INDEXING` is set to `true`
+and display a notice in the WordPress dashboard with a reference to the value of
+[`WP_ENV`](https://docs.roots.io/bedrock/master/environment-variables/#wp-env) or
+[`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/).
 
 ## Support us
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Overview
 
-This plugin will prevent indexing of a site when `WP_ENV` is not set to `production`.
+This plugin will prevent indexing of a site when [`WP_ENV`](https://docs.roots.io/bedrock/master/environment-variables/#wp-env) or [`wp_get_environment_type()`](https://developer.wordpress.org/reference/functions/wp_get_environment_type/) is not set to `production`.
 
 ## Support us
 

--- a/bedrock-disallow-indexing.php
+++ b/bedrock-disallow-indexing.php
@@ -22,11 +22,28 @@ add_action('admin_init', function () {
     }
 
     add_action('admin_notices', function () {
-        $message = sprintf(
-            __('%1$s Search engine indexing has been discouraged because the current environment is %2$s.', 'roots'),
-            '<strong>Bedrock:</strong>',
-            '<code>'.WP_ENV.'</code>'
-        );
+        if (defined('WP_ENV') && WP_ENV) {
+            $wp_env = WP_ENV;
+        } else if (function_exists('wp_get_environment_type')) {
+            $wp_env = wp_get_environment_type();
+        } else {
+            $wp_env = null;
+        }
+
+        $wp_env = apply_filters('roots/bedrock/disallow_indexing_environment_type', $wp_env);
+        if ($wp_env) {
+            $message = sprintf(
+                __('%1$s Search engine indexing has been discouraged because the current environment is %2$s.', 'roots'),
+                '<strong>Bedrock:</strong>',
+                '<code>'.$wp_env.'</code>'
+            );
+        } else {
+            $message = sprintf(
+                __('%1$s Search engine indexing has been discouraged.', 'roots'),
+                '<strong>Bedrock:</strong>'
+            );
+        }
+
         echo "<div class='notice notice-warning'><p>{$message}</p></div>";
     });
 });

--- a/bedrock-disallow-indexing.php
+++ b/bedrock-disallow-indexing.php
@@ -22,28 +22,34 @@ add_action('admin_init', function () {
     }
 
     add_action('admin_notices', function () {
-        if (defined('WP_ENV') && WP_ENV) {
-            $wp_env = WP_ENV;
-        } else if (function_exists('wp_get_environment_type')) {
-            $wp_env = wp_get_environment_type();
-        } else {
-            $wp_env = null;
+        $env = defined('WP_ENV') && WP_ENV ? WP_ENV : null;
+
+        if (!$env && function_exists('wp_get_environment_type')) {
+            $env = wp_get_environment_type();
         }
 
-        $wp_env = apply_filters('roots/bedrock/disallow_indexing_environment_type', $wp_env);
-        if ($wp_env) {
-            $message = sprintf(
+        $env = apply_filters('roots/bedrock/disallow_indexing_environment_type', $env);
+
+        if (!$env) {
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                sprintf(
+                    /* translators: %s: Bedrock prefix. */
+                    __('%s Search engine indexing has been discouraged.', 'roots'),
+                    '<strong>Bedrock:</strong>'
+                )
+            );
+            return;
+        }
+
+        printf(
+            '<div class="notice notice-warning"><p>%s</p></div>',
+            sprintf(
+                /* translators: 1: Bedrock prefix, 2: Environment type. */
                 __('%1$s Search engine indexing has been discouraged because the current environment is %2$s.', 'roots'),
                 '<strong>Bedrock:</strong>',
-                '<code>'.$wp_env.'</code>'
-            );
-        } else {
-            $message = sprintf(
-                __('%1$s Search engine indexing has been discouraged.', 'roots'),
-                '<strong>Bedrock:</strong>'
-            );
-        }
-
-        echo "<div class='notice notice-warning'><p>{$message}</p></div>";
+                '<code>' . $env . '</code>'
+            )
+        );
     });
 });

--- a/bedrock-disallow-indexing.php
+++ b/bedrock-disallow-indexing.php
@@ -24,7 +24,7 @@ add_action('admin_init', function () {
     add_action('admin_notices', function () {
         $env = defined('WP_ENV') && WP_ENV ? WP_ENV : null;
 
-        if (!$env && function_exists('wp_get_environment_type')) {
+        if (!$env) {
             $env = wp_get_environment_type();
         }
 
@@ -48,7 +48,7 @@ add_action('admin_init', function () {
                 /* translators: 1: Bedrock prefix, 2: Environment type. */
                 __('%1$s Search engine indexing has been discouraged because the current environment is %2$s.', 'roots'),
                 '<strong>Bedrock:</strong>',
-                '<code>' . $env . '</code>'
+                '<code>' . esc_html($env) . '</code>'
             )
         );
     });


### PR DESCRIPTION
Fixed the description of the plugin in the README to indicate that it relies on the value of a `DISALLOW_INDEXING` constant and not `WP_ENV`. The latter constant only being used as a reference in an dashboard notice.

Also added support for `WP_ENVIRONMENT_TYPE` and support for omitting `WP_ENV`. Proposed behaviour:

1. Resolve the environment type:
	1. Use the value of the `WP_ENV` constant if defined and palpable.
	2. Otherwise, use the value of the `wp_get_environment_type()` function if defined (introduced in WordPress 5.0.0).
	3. Otherwise, use `NULL`.
2. Filter the environment type with the following hook:
	* `roots/bedrock/disallow_indexing_environment_type`
3. Display the notice:
	1. If the environment type is palpable, display the notice with the filtered environment type.
	2. Otherwise, display a shorter notice that does not reference the environment type.