### PR TITLE
Require PHP 8.2+ and add Pint CI workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes export-ignore
+/.github export-ignore

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3, 8.4, 8.5]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/bedrock-disallow-indexing.php
+++ b/bedrock-disallow-indexing.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 Plugin Name:  Disallow Indexing
 Plugin URI:   https://roots.io/bedrock/
@@ -10,27 +11,27 @@ Text Domain:  roots
 License:      MIT License
 */
 
-if (!defined('DISALLOW_INDEXING') || DISALLOW_INDEXING !== true) {
+if (! defined('DISALLOW_INDEXING') || DISALLOW_INDEXING !== true) {
     return;
 }
 
 add_action('pre_option_blog_public', '__return_zero');
 
 add_action('admin_init', function () {
-    if (!apply_filters('roots/bedrock/disallow_indexing_admin_notice', true)) {
+    if (! apply_filters('roots/bedrock/disallow_indexing_admin_notice', true)) {
         return;
     }
 
     add_action('admin_notices', function () {
         $env = defined('WP_ENV') && WP_ENV ? WP_ENV : null;
 
-        if (!$env) {
+        if (! $env) {
             $env = wp_get_environment_type();
         }
 
         $env = apply_filters('roots/bedrock/disallow_indexing_environment_type', $env);
 
-        if (!$env) {
+        if (! $env) {
             printf(
                 '<div class="notice notice-warning"><p>%s</p></div>',
                 sprintf(
@@ -39,6 +40,7 @@ add_action('admin_init', function () {
                     '<strong>Bedrock:</strong>'
                 )
             );
+
             return;
         }
 
@@ -48,7 +50,7 @@ add_action('admin_init', function () {
                 /* translators: 1: Bedrock prefix, 2: Environment type. */
                 __('%1$s Search engine indexing has been discouraged because the current environment is %2$s.', 'roots'),
                 '<strong>Bedrock:</strong>',
-                '<code>' . esc_html($env) . '</code>'
+                '<code>'.esc_html($env).'</code>'
             )
         );
     });

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "forum": "https://discourse.roots.io/"
   },
   "require": {
-    "php": ">=7.1"
+    "php": ">=8.2"
+  },
+  "require-dev": {
+    "laravel/pint": "^1.27"
   }
 }


### PR DESCRIPTION
## Summary
- Bump minimum PHP requirement from 7.1 to 8.2
- Add Laravel Pint as a dev dependency with a CI workflow
- Apply Pint formatting to plugin file

🤖 Generated with [Claude Code](https://claude.com/claude-code)